### PR TITLE
Allow Disabling Creation of Public DNS

### DIFF
--- a/o.route53.tf
+++ b/o.route53.tf
@@ -1,7 +1,7 @@
 # Titan Network Module - Route 53 Outputs
 
 output delegation_set_id {
-  value = aws_route53_delegation_set.default.id
+  value = var.public_dns ? aws_route53_delegation_set.default[0].id : null
 
   description = <<-EOF
     Unique identifier for the Route 53 delegation set associated with the public Route 53 hosted zone for this Titan
@@ -12,7 +12,7 @@ output delegation_set_id {
 }
 
 output delegation_set_name_servers {
-  value = aws_route53_delegation_set.default.name_servers
+  value = var.public_dns ? aws_route53_delegation_set.default[0].name_servers : null
 
   description = <<-EOF
     A set of Amazon name servers serving the public Route 53 hosted zone for this Titan network.
@@ -44,7 +44,7 @@ output private_zone_id {
 }
 
 output public_zone_id {
-  value = aws_route53_zone.public.zone_id
+  value = var.public_dns ? aws_route53_zone.public[0].zone_id : null
 
   description = <<-EOF
     The Amazon hosted zone identifier for the public Route 53 hosted zone for this Titan network.

--- a/r.route53.tf
+++ b/r.route53.tf
@@ -2,13 +2,17 @@
 
 # Set of Name Servers for Public DNS Resolution
 resource aws_route53_delegation_set default {
+  count = var.public_dns ? 1 : 0
+
   reference_name = "${var.name_short}.${var.domain}"
 }
 
 # Public Route 53 Hosted Zone
 resource aws_route53_zone public {
+  count = var.public_dns ? 1 : 0
+
   name = "${var.name_short}.${var.domain}"
-  delegation_set_id = aws_route53_delegation_set.default.id
+  delegation_set_id = aws_route53_delegation_set.default[0].id
 
   tags = merge(
     {

--- a/v.route53.tf
+++ b/v.route53.tf
@@ -11,3 +11,14 @@ variable domain {
     Examples: `mydomain.com`, `mycompanydomain.com`, `uswest1.mydomain.com`. 
   EOF
 }
+
+variable public_dns {
+  type = bool
+  default = true
+
+  description = <<-EOF
+    Whether to create a public Route 53 hosted zone.
+
+    If you are hosting your public DNS elsewhere, you should probably set this to false.
+  EOF
+}


### PR DESCRIPTION
Provide a variable `public_dns` which will allow opting out of creating a public Route 53 zone.